### PR TITLE
Adding missing function clause to let cb_admin/module handle null-atoms ...

### DIFF
--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -333,6 +333,8 @@ data_type(_, _Val) when is_tuple(_Val) ->
     "datetime";
 data_type(_, _Val) when is_boolean(_Val) ->
     "boolean";
+data_type(_, null) ->
+    "null";
 data_type(_, undefined) ->
     "null";
 data_type('id', _) ->


### PR DESCRIPTION
...from the PostgresQL-adapter.
