### PR TITLE
Make sure the value that goes in the WHERE-clause is the number, not the...

### DIFF
--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -175,8 +175,8 @@ activate_record(Record, Metadata, Type) ->
 keyindex(Key, N, TupleList) ->
     keyindex(Key, N, TupleList, 1).
 
-keyindex(_Key, _N, [], _Index) ->
-    undefined;
+keyindex(Key, _N, [], _Index) ->
+    throw({error, "Expected attribute '" ++ binary_to_list(Key) ++ "' was not found in Postgres query results. Synchronise your model and dat
 keyindex(Key, N, [Tuple|Rest], Index) ->
     case element(N, Tuple) of
         Key -> Index;


### PR DESCRIPTION
... whole "record-idnum" string. That broke the SQl-query.

It allows to assert([boss_db:find("type-nnn")] == boss_db:find(type, [{id, equals, "type-nnn"}])
