### PR TITLE
Fixed typo

### DIFF
--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -176,7 +176,7 @@ keyindex(Key, N, TupleList) ->
     keyindex(Key, N, TupleList, 1).
 
 keyindex(Key, _N, [], _Index) ->
-    throw({error, "Expected attribute '" ++ binary_to_list(Key) ++ "' was not found in Postgres query results. Synchronise your model and dat
+    throw({error, "Expected attribute '" ++ binary_to_list(Key) ++ "' was not found in Postgres query results. Synchronise your model and data'"});
 keyindex(Key, N, [Tuple|Rest], Index) ->
     case element(N, Tuple) of
         Key -> Index;


### PR DESCRIPTION
Hi Evan,

I fixed a typo in the PostgreSQL adapter.  Looked like a cut and paste error but it prevented boss_db from successful compiling.

—Kai
