### PR TITLE
Fix cache adapter name bug & help to try to fix boss_cache pool problem

### DIFF
--- a/src/boss_cache.erl
+++ b/src/boss_cache.erl
@@ -10,7 +10,8 @@ start() ->
     start([{adapter, Adapter}, {cache_servers, [{"127.0.0.1", 11211, 1}]}]).
 
 start(Options) ->
-    Adapter = proplists:get_value(adapter, Options, boss_cache_adapter_memcached_bin),
+    AdapterName = proplists:get_value(adapter, Options, memcached_bin),
+    Adapter = list_to_atom(lists:concat(["boss_cache_adapter_", AdapterName])),
     Adapter:start(Options),
     boss_cache_sup:start_link(Options).
 


### PR DESCRIPTION
Hi Evan,

This patchs solves the adapter name bug in boss_cache not working from boss_db repo movement.

Boss_cache still does not work, the pollboy integration has problems:

boss_cache_controller (called from poolboy in boss_cache_sup:init/1) expects:
- {ok, Conn} = Adapter:init(Options),
  But erlmc returns only ok (not the PID)

I changed this in erlmc:start/1 but I think that this is no ok: if erlmc has its own pool management, we are duplicating?

I need some help here about the design.

Thanks Evan!
