### PR TITLE
Adding 'regex' token to pass in a regular expression for find

### DIFF
--- a/src/db_adapters/boss_db_adapter_mongodb.erl
+++ b/src/db_adapters/boss_db_adapter_mongodb.erl
@@ -204,6 +204,8 @@ build_conditions1([{Key, Operator, Value}|Rest], Acc) ->
             [{Key, {'$not', {regex, list_to_binary(Value), <<"">>}}}];
         {'matches', Value} ->
             [{Key, {regex, list_to_binary(Value), <<"">>}}];
+	{'regex', Value} ->
+	    [{Key, {regex, Value, <<"">>}}];
         {'contains', Value} ->
             WhereClause = where_clause(
                 ?CONTAINS_FORMAT, [Key, Value]),


### PR DESCRIPTION
Hi Evan,

with this patch one can pass in something like this:

boss_db:find(article, [{title, 'regex', SearchTerm}])

where SearchTerm can be a PCRE regular expression.

--Kai
