### PR TITLE
Pack null atom

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -382,6 +382,8 @@ pack_datetime(DateTime) ->
 
 pack_now(Now) -> pack_datetime(calendar:now_to_datetime(Now)).
 
+pack_value(null) ->
+	"null";
 pack_value(undefined) ->
 	"null";
 pack_value(V) when is_binary(V) ->


### PR DESCRIPTION
Hi,

I think that aside from packing the undefined atom as "null" it would be nice if the null atom is packed as "null" too.

By the way. Why don't convert all atoms to binaries and them pack them as that?
