### PR TITLE
Support date type on mysql adapter

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -429,6 +429,8 @@ pack_value(V) when is_list(V) ->
     "'" ++ escape_sql(V) ++ "'";
 pack_value({MegaSec, Sec, MicroSec}) when is_integer(MegaSec) andalso is_integer(Sec) andalso is_integer(MicroSec) ->
     pack_now({MegaSec, Sec, MicroSec});
+pack_value({date, Date = {_,_,_}}) ->    
+    pack_datetime({Date,{0,0,0}});    
 pack_value({{_, _, _}, {_, _, _}} = Val) ->
     pack_datetime(Val);
 pack_value(Val) when is_integer(Val) ->


### PR DESCRIPTION
Hi guys,

we're facing the case of having date types columns on our mysql schema.  

We don't have a date type on boss_db , I guess because on erlang we deal only with datetimes and now-like structure.

Storing dates and query using them is working if you pad them as datetimes ({Date, {0,0,0}}) so no problem here.

The only problem is when you try to read or update an already present element that includes a date type row. We got something like that

[{boss_db_adapter_mysql,pack_value,
                           [{date,{2012,7,31}}],
                           [{file,"src/db_adapters/boss_db_adapter_mysql.erl"},
                            {line,422}]},

I added support for this case so when we recover a date value from mysql db is gracefully translated to their datetime version.
