### PR TITLE
Fix float data-type

### DIFF
--- a/src/boss_record_lib.erl
+++ b/src/boss_record_lib.erl
@@ -113,4 +113,6 @@ convert_value_to_type("false", boolean) -> false;
 convert_value_to_type(1, boolean) -> true;
 convert_value_to_type(0, boolean) -> false;
 convert_value_to_type(true, boolean) -> true;
-convert_value_to_type(false, boolean) -> false.
+convert_value_to_type(false, boolean) -> false;
+
+convert_value_to_type(Val, float) -> Val.


### PR DESCRIPTION
Added convert_value_to_type => float

Fixes float model data type (is ok for mysql, other adapter can need some conversions)
