### PR TITLE
When inserting, skip when id not yet defined (and let DB manage).

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -256,6 +256,7 @@ build_insert_query(Record) ->
     AttributeColumns = Record:database_columns(),
     {Attributes, Values} = lists:foldl(fun
             ({_, undefined}, Acc) -> Acc;
+            ({'id', 'id'}, Acc) -> Acc;
             ({'id', V}, {Attrs, Vals}) when is_integer(V) -> 
                  {[atom_to_list(id)|Attrs], [pack_value(V)|Vals]};
             ({'id', V}, {Attrs, Vals}) -> 

--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -204,6 +204,7 @@ build_insert_query(Record) ->
     AttributeColumns = Record:database_columns(),
     {Attributes, Values} = lists:foldl(fun
             ({_, undefined}, Acc) -> Acc;
+            ({'id', 'id'}, Acc) -> Acc;
             ({'id', V}, {Attrs, Vals}) -> 
                 DBColumn = proplists:get_value('id', AttributeColumns),
                 {_, _, _, TableId} = boss_sql_lib:infer_type_from_id(V),


### PR DESCRIPTION
When creating a new record, boss_db incorrectly tries to infer type from id before the record has been saved and assigned an id. For a new record the A/V tuple is `{id, id}`, and upon building the insert query `boss_db_adapter_(mysql|pgsql):build_insert_query/1` calls `boss_sql_lib:infer_type_from_id(V)`. This function is undefined for atoms, which is the case when the record hasn't yet been saved. This patch corrects this behaviour by returning the accumulator unchanged when processing a `{id, id}` tuple.

Note that the patch has only been tested with PostgreSQL -- no testing has been done using MySQL code.

For clarity, here's the error returned by CB when trying to insert a "category" record (`[Id, Name::string()]`):

``` erlang
** exception exit: {{function_clause,[{boss_sql_lib,infer_type_from_id,
                                                    [id],
                                                    [{file,"src/boss_sql_lib.erl"},{line,17}]},
                                      {boss_db_adapter_pgsql,'-build_insert_query/1-fun-0-',3,
                                                             [{file,"src/db_adapters/boss_db_adapter_pgsql.erl"},
                                                              {line,209}]},
                                      {lists,foldl,3,[{file,"lists.erl"},{line,1197}]},
                                      {boss_db_adapter_pgsql,build_insert_query,1,
                                                             [{file,"src/db_adapters/boss_db_adapter_pgsql.erl"},
                                                              {line,205}]},
                                      {boss_db_adapter_pgsql,save_record,2,
                                                             [{file,"src/db_adapters/boss_db_adapter_pgsql.erl"},
                                                              {line,107}]},
                                      {boss_db_controller,handle_call,3,
                                                          [{file,"src/boss_db_controller.erl"},{line,123}]},
                                      {gen_server,handle_msg,5,
                                                  [{file,"gen_server.erl"},{line,588}]},
                                      {proc_lib,init_p_do_apply,3,
                                                [{file,"proc_lib.erl"},{line,227}]}]},
                    {gen_server,call,
                                [<0.82.0>,{save_record,{category,id,"hacks"}},30000]}}
```
