### PR TITLE
Take null into account when building conditions

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -326,11 +326,11 @@ build_conditions(Type, Conditions) ->
 
 build_conditions1([], Acc) ->
     Acc;
-build_conditions1([{Key, 'equals', Value}|Rest], Acc) when Value == undefined ->
+build_conditions1([{Key, 'equals', Value}|Rest], Acc) when Value == undefined ; Value == null->
     build_conditions1(Rest, add_cond(Acc, Key, "is", pack_value(Value)));
 build_conditions1([{Key, 'equals', Value}|Rest], Acc) ->
     build_conditions1(Rest, add_cond(Acc, Key, "=", pack_value(Value)));
-build_conditions1([{Key, 'not_equals', Value}|Rest], Acc) when Value == undefined ->
+build_conditions1([{Key, 'not_equals', Value}|Rest], Acc) when Value == undefined ; Value == null ->
     build_conditions1(Rest, add_cond(Acc, Key, "is not", pack_value(Value)));
 build_conditions1([{Key, 'not_equals', Value}|Rest], Acc) ->
     build_conditions1(Rest, add_cond(Acc, Key, "!=", pack_value(Value)));


### PR DESCRIPTION
(Related with issue #39)

Hi again, 

Today trying to do a query based on a null condition I noticed that aside from packing null as "null" other changes need to be made so that everything is balanced. I mean using "null" as a trigger for the 'is' operator in mysql.

So aside from doing this kind of query `boss_db:find(module, [{field, 'equals', undefined}])` this could be used `boss_db:find(module, [{field, 'equals', null}])`
