### PR TITLE
Switch to 'master' of 'mongodb' for making the mongo adapter work properly.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
     {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", {tag, "1.4"}}},
     {erlmc, ".*", {git, "git://github.com/bipthelin/erlmc.git", {tag, "HEAD"}}},
     {medici, ".*", {git, "git://github.com/evanmiller/medici.git", {branch, "rebarify"}}},
-    {mongodb, ".*", {git, "git://github.com/mongodb/mongodb-erlang.git", {tag, "613f157c66"}}},
+    {mongodb, ".*", {git, "git://github.com/mongodb/mongodb-erlang.git", {branch, "master"}}},
     {mysql, ".*", {git, "git://github.com/dizzyd/erlang-mysql-driver.git", {tag, "16cae84b5e"}}},
     {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "855802e0cc"}}},
     {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.0"}}},


### PR DESCRIPTION
I think mongodb-erlang is making some big refactoring now, and because of some reason I don't know, the mongodb repo tag in rebar.config isn't working anymore, it will refer to some tag in the other branch which is not compatible to boss_db, but the master branch is still working now, so we should change to use the 'master' branch of mongodb driver.
