### PR TITLE
Riak Adapter Improvements

### DIFF
--- a/src/db_adapters/boss_db_adapter_riak.erl
+++ b/src/db_adapters/boss_db_adapter_riak.erl
@@ -229,11 +229,7 @@ riak_search_encode_value(V) ->
     V.
 
 riak_search_decode_data(Data) ->
-    lists:map(fun({K, V}) ->
-        DecodedKey = riak_search_decode_key(K),
-        DecodedValue = riak_search_decode_value(V),
-        {DecodedKey, DecodedValue}
-    end, Data).
+    [{riak_search_decode_key(K), riak_search_decode_value(V)} || {K, V} <- Data].
 
 riak_search_decode_key(K) ->
     list_to_atom(binary_to_list(K)).


### PR DESCRIPTION
This PR does two things:
1. Changes the way data is "serialized" to Riak, so that riak_search indexes it
2. Removes the client-side key-generation, because the server can do that for us

Since I only started learning Erlang recently, feel free to critique (and possibly mock) my changes :smile:
