### PR TITLE
Fixed epgsql dependance tuple.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
     {aleppo, ".*", {git, "git://github.com/evanmiller/aleppo.git", {tag, "bef139e4c7"}}},
     {bson, ".*", {git, "git://github.com/mongodb/bson-erlang.git", {tag, "6d3cc910ea"}}},
     {ddb, ".*", {git, "git://github.com/Concurix/ddb.git", {tag, "HEAD"}}},
-    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "3318bd5d64"}},
+    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", {tag, "3318bd5d64"}}},
     {erlmc, ".*", {git, "git://github.com/bipthelin/erlmc.git", {tag, "HEAD"}}},
     {medici, ".*", {git, "git://github.com/evanmiller/medici.git", {branch, "rebarify"}}},
     {mongodb, ".*", {git, "git://github.com/evanmiller/mongodb-erlang.git",   {tag, "c582c911cd"}}},


### PR DESCRIPTION
Previously, git was set to check out a specific file, "origin/3318bd5d64", which probably wasn't intended. This commit tags the correct revision in rebar.config.
