### PR TITLE
[#104] Fix for Infinite loop on start-up with sharding enabled

### DIFF
--- a/src/boss_db_controller.erl
+++ b/src/boss_db_controller.erl
@@ -243,7 +243,12 @@ handle_cast({try_connect, Options}, State) when State#state.connection_state /= 
 								undefined -> ShardOptions ++ proplists:delete(db_replication_set, Options);
 								_ -> ShardOptions ++ Options
 							    end,
-					    {ok, {ShardRead, ShardWrite}} = ShardAdapter:init(MergedOptions),
+					    case ShardAdapter:init(MergedOptions) of
+						{ok, {ShardRead, ShardWrite}} -> 
+						    noop;
+						{ok, Conn} ->
+						    [ShardRead, ShardWrite] = [Conn, Conn]
+						end,
 					    Index = erlang:length(ShardAcc),
 					    NewDict = lists:foldr(fun(ModelAtom, Dict) ->
 									  dict:store(ModelAtom, Index, Dict)


### PR DESCRIPTION
Simple fix for ticket 104 to work around change to sharding init. Tested on postgres 9.1 but it looks like the fix will solve the same issue with the other db_adapters.
