### PR TITLE
Fix how we're handling the metadata/counter field in DynamoDB

### DIFF
--- a/src/db_adapters/boss_db_adapter_dynamodb.erl
+++ b/src/db_adapters/boss_db_adapter_dynamodb.erl
@@ -184,8 +184,17 @@ convert_type_to_ddb(undefined) ->
     'string'.
 
 init_meta_entry(Model) when is_binary(Model)->
-	ddb:put(Model, [{<<"id">>, <<"metadata">>, 'string'},
-					{<<"counter">>, <<"0">>, 'number'}]).
+    ModelAtom = binary_to_atom(Model, latin1),
+    Attributes = ModelAtom:module_info(attributes),
+    case proplists:get_value(primary_key, Attributes) of
+        undefined ->
+            ddb:put(Model, [{<<"id">>, <<"__metadata">>, 'string'},
+                            {<<"__counter">>, <<"0">>, 'number'}]);
+        [Field] ->
+            FieldBin = atom_to_binary(Field, latin1),
+            ddb:put(Model, [{FieldBin, <<"__metadata">>, 'string'},
+                            {<<"__counter">>, <<"0">>, 'number'}])
+    end.
 
 %%
 %% Helper functions for creating records
@@ -196,10 +205,8 @@ create_new(Record) ->
 	Attrs = SavedRec:attributes(),
 	%% WEIRD: dynamodb does not allow empty strings as values, don't store them.
 	Fields = [ {atom_to_binary(K,latin1), val_to_binary(V), type_of(V)} || {K, V} <- Attrs, not_empty(V) ],
-
-	_Res = ddb:put(atom_to_binary(Model, latin1), Fields),
-
-	{ok, SavedRec}.
+	ddb:put(atom_to_binary(Model, latin1), Fields),
+    {ok, SavedRec}.
 
 update_existing(Record) ->
 	Model  = element(1, Record),
@@ -266,7 +273,7 @@ create_from_ddbitem_list(_Model, []) ->
 create_from_ddbitem_list(Model, [Item | Tail]) ->
 	%% skip any metadata entries
 	case proplists:get_value(<<"id">>, Item) of
-		[{<<"S">>, <<"metadata">>}] ->
+		[{<<"S">>, <<"__metadata">>}] ->
 			create_from_ddbitem_list(Model, Tail);
 		_X ->
 			[create_from_ddbitem(Model, Item) | create_from_ddbitem_list(Model, Tail) ]
@@ -306,16 +313,16 @@ list_to_term(String) ->
 get_new_unique_id(Model) when is_atom(Model) ->
 	get_new_unique_id(erlang:atom_to_binary(Model, latin1));
 get_new_unique_id(Model) when is_binary(Model) ->
-	{ok, Ret} = ddb:get(Model, ddb:key_value(<<"metadata">>, 'string')),
+	{ok, Ret} = ddb:get(Model, ddb:key_value(<<"__metadata">>, 'string')),
 	case proplists:get_value(<<"Item">>, Ret) of
 		undefined ->
 			init_meta_entry(Model),
 			get_new_unique_id(Model);
 		Attrs ->
-			[{<<"N">>, CounterBin}] = proplists:get_value(<<"counter">>, Attrs),
+			[{<<"N">>, CounterBin}] = proplists:get_value(<<"__counter">>, Attrs),
 			Counter = list_to_term(binary_to_list(CounterBin)),
 			Id = Counter + 1,
-			ddb:update(Model, ddb:key_value(<<"metadata">>, 'string'), [{<<"counter">>, list_to_binary(io_lib:format("~p", [Id])), 'number', 'put'}]),
+			ddb:update(Model, ddb:key_value(<<"__metadata">>, 'string'), [{<<"__counter">>, list_to_binary(io_lib:format("~p", [Id])), 'number', 'put'}]),
 			lists:flatten(io_lib:format("~p-~p", [binary_to_atom(Model, latin1), Id]))
 	end.
 


### PR DESCRIPTION
If a model had the primary_key-attribute on a field other than "id" the dynamodb-adapter would run into an infinite loop and crash.
