### PR TITLE
DynamoDB improvements

### DIFF
--- a/src/db_adapters/boss_db_adapter_dynamodb.erl
+++ b/src/db_adapters/boss_db_adapter_dynamodb.erl
@@ -279,7 +279,15 @@ create_from_ddbitem_list(_Model, []) ->
 	[];
 create_from_ddbitem_list(Model, [Item | Tail]) ->
 	%% skip any metadata entries
-	case proplists:get_value(<<"id">>, Item) of
+    PrimaryKey =
+        case proplists:get_value(primary_key, Model:module_info(attributes)) of
+            undefined ->
+                <<"id">>;
+            [Key] ->
+                atom_to_binary(Key, latin1)
+        end,
+
+	case proplists:get_value(PrimaryKey, Item) of
 		[{<<"S">>, <<"__metadata">>}] ->
 			create_from_ddbitem_list(Model, Tail);
 		_X ->


### PR DESCRIPTION
- Added correct handling of booleans
- Hides the __metadata-records when querying.
- Fixes a bug where if a primary key was set on a field other than "id" the dynamodb adapter would get into an infinite loop and crash.
