### PR TITLE
Support ETS cache with TTL

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,6 @@
     {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.0"}}},
     {tiny_pq, ".*", {git, "git://github.com/evanmiller/tiny_pq", {tag, "HEAD"}}},
     {uuid, ".*", {git, "git://gitorious.org/avtobiff/erlang-uuid.git", "master"}},
-    {redo, ".*", {git, "git://github.com/JacobVorreuter/redo.git",    "HEAD"}}
+    {redo, ".*", {git, "git://github.com/JacobVorreuter/redo.git",    "HEAD"}},
+    {ets_cache, ".*", {git, "git://github.com/cuongth/ets_cache.git", {tag, "9bde6c53b7"}}}
   ]}.

--- a/src/cache_adapters/boss_cache_adapter_ets.erl
+++ b/src/cache_adapters/boss_cache_adapter_ets.erl
@@ -1,0 +1,46 @@
+-module (boss_cache_adapter_ets).
+-author('bronzeboyvn@gmail.com').
+-behaviour(boss_cache_adapter).
+
+-export([init/1, start/0, start/1, stop/1]).
+-export([get/3, set/5, delete/3]).
+
+start() ->
+    cache_server:start_link(),
+    check_server:start_link(),
+    ok.
+
+start(Options) ->
+    cache_server:start_link(Options),
+    check_server:start_link(Options),
+    ok.
+
+stop(_Conn) ->
+    cache_server:stop(),
+    check_server:stop(),
+    ok.
+
+init(_Options) ->
+    {ok, undefined}.
+
+get(_Conn, Prefix, Key) ->
+    Term2Key = term_to_key(Prefix, Key),
+    case cache_server:get(Term2Key) of
+        <<>> ->
+            undefined;
+        Bin ->
+            binary_to_term(Bin)
+    end.
+
+set(_Conn, Prefix, Key, Val, TTL) ->
+    Term2Key = term_to_key(Prefix, Key),
+    ValBin = term_to_binary(Val),
+    cache_server:set(Term2Key, ValBin, TTL).
+
+delete(_Conn, Prefix, Key) ->
+    Term2Key = term_to_key(Prefix, Key),
+    cache_server:delete(Term2Key).
+
+% internal
+term_to_key(Prefix, Term) ->
+    lists:concat([Prefix, ":", mochihex:to_hex(erlang:md5(term_to_binary(Term)))]).


### PR DESCRIPTION
I've added boss_cache_adapter_ets.erl that uses my ets_cache. I've create new app and it runs normally.
Could you guide me how to test to be sure that this adapter doesn't break your boss_db ?
