### PR TITLE
Fix handling updates with undefined (aka null) values

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -301,6 +301,8 @@ build_update_query(Record) ->
                     {true, true} ->
                         {_, _, _, ForeignId} = boss_sql_lib:infer_type_from_id(V),
                         ForeignId;
+                    {_, false} ->
+                        null;
                     _ ->
                         V
                 end,

--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -264,6 +264,8 @@ build_update_query(Record) ->
                     {true, true} ->
                         {_, _, _, ForeignId} = boss_sql_lib:infer_type_from_id(V),
                         ForeignId;
+                    {_, false} ->
+                        null;
                     _ ->
                         V
                 end,


### PR DESCRIPTION
epgsql does not handle updates with 'undefined' values and boss_db does not understand 'null' value. This leads to a funny error when you read a record with null value in foreign key column and try to save it. If the field stays set to 'undefined', epgsql complains and when it is set manually to 'null', boss_db complains that it cannot guess record type from this value.

I decided that most consistent solution will be to convert 'undefined' to 'null' in boss_db. MySQL driver does not require such fix but for sake of symmetry I also "fixed" MySQL adapter.
