### PR TITLE
remove mochihex:to_hex deps, for project not using mochiweb as webserver

### DIFF
--- a/src/boss_cache.erl
+++ b/src/boss_cache.erl
@@ -2,7 +2,7 @@
 -export([start/0, start/1]).
 -export([stop/0]).
 -export([get/2, set/4, delete/2]).
-
+-export([to_hex/1]).
 -define(POOLNAME, boss_cache_pool).
 
 start() ->
@@ -26,3 +26,33 @@ get(Prefix, Key) ->
 
 delete(Prefix, Key) ->
     boss_pool:call(?POOLNAME, {delete, Prefix, Key}).
+
+
+%% from mochiweb project, mochihex:to_hex/1
+%% @spec to_hex(integer | iolist()) -> string()
+%% @doc Convert an iolist to a hexadecimal string.
+to_hex(0) ->
+    "0";
+to_hex(I) when is_integer(I), I > 0 ->
+    to_hex_int(I, []);
+to_hex(B) ->
+    to_hex(iolist_to_binary(B), []).
+
+%% @spec hexdigit(integer()) -> char()
+%% @doc Convert an integer less than 16 to a hex digit.
+hexdigit(C) when C >= 0, C =< 9 ->
+    C + $0;
+hexdigit(C) when C =< 15 ->
+    C + $a - 10.
+
+%% Internal API
+
+to_hex(<<>>, Acc) ->
+    lists:reverse(Acc);
+to_hex(<<C1:4, C2:4, Rest/binary>>, Acc) ->
+    to_hex(Rest, [hexdigit(C2), hexdigit(C1) | Acc]).
+
+to_hex_int(0, Acc) ->
+    Acc;
+to_hex_int(I, Acc) ->
+    to_hex_int(I bsr 4, [hexdigit(I band 15) | Acc]).

--- a/src/cache_adapters/boss_cache_adapter_ets.erl
+++ b/src/cache_adapters/boss_cache_adapter_ets.erl
@@ -46,4 +46,4 @@ delete(_Conn, Prefix, Key) ->
 
 % internal
 term_to_key(Prefix, Term) ->
-    lists:concat([Prefix, ":", mochihex:to_hex(erlang:md5(term_to_binary(Term)))]).
+    lists:concat([Prefix, ":", boss_cache:to_hex(erlang:md5(term_to_binary(Term)))]).

--- a/src/cache_adapters/boss_cache_adapter_memcached_bin.erl
+++ b/src/cache_adapters/boss_cache_adapter_memcached_bin.erl
@@ -37,4 +37,4 @@ delete(_Conn, Prefix, Key) ->
 
 % internal
 term_to_key(Prefix, Term) ->
-    lists:concat([Prefix, ":", mochihex:to_hex(erlang:md5(term_to_binary(Term)))]).
+    lists:concat([Prefix, ":", boss_cache:to_hex(erlang:md5(term_to_binary(Term)))]).

--- a/src/cache_adapters/boss_cache_adapter_redis.erl
+++ b/src/cache_adapters/boss_cache_adapter_redis.erl
@@ -38,4 +38,4 @@ delete(Conn, Prefix, Key) ->
 
 % internal
 term_to_key(Prefix, Term) ->
-    lists:concat([Prefix, ":", mochihex:to_hex(erlang:md5(term_to_binary(Term)))]).
+    lists:concat([Prefix, ":", boss_cache:to_hex(erlang:md5(term_to_binary(Term)))]).


### PR DESCRIPTION
prevent boss_cache to crash when mochiweb is not in the list of deps application.
