### PR TITLE
Unpack datetime values in mongo adapter.

### DIFF
--- a/src/db_adapters/boss_db_adapter_mongodb.erl
+++ b/src/db_adapters/boss_db_adapter_mongodb.erl
@@ -469,6 +469,8 @@ pack_value(V) -> V.
 
 unpack_value(_AttrName, [H|T], _ValueType) when is_integer(H) ->
     {integers, [H|T]};
+unpack_value(_AttrName, {_, _, _} = Value, datetime) ->
+    calendar:now_to_datetime(Value);
 unpack_value(AttrName, Value, ValueType) ->
     case is_id_attr(AttrName) and (Value =/= "") of 
         true -> 


### PR DESCRIPTION
The MongoDB adapter packs datetimes as {MegaSeconds, Seconds, MicroSeconds}, but doesn't unpack them again. This patch is intended to fix that, and should AFAICT also resolve #102.
