### PR TITLE
When floats are returned as binaries from the database driver, convert them accordingly.

### DIFF
--- a/src/boss_record_lib.erl
+++ b/src/boss_record_lib.erl
@@ -83,6 +83,8 @@ convert_value_to_type(Val, integer) when is_list(Val) ->
     list_to_integer(Val);
 convert_value_to_type(Val, integer) when is_binary(Val) ->
     list_to_integer(binary_to_list(Val));
+convert_value_to_type(Val, float) when is_binary(Val) ->
+    binary_to_float(Val);
 convert_value_to_type(Val, float) when is_float(Val) -> 
     Val;
 convert_value_to_type(Val, float) when is_integer(Val) -> 


### PR DESCRIPTION
I'm not 100% sure whether this is _the_ correct approach, but at least the epgsql driver seems to convert floats to binaries, and when ::float() is specified for a given model attribute, that will be returned as a binary from the driver causing a function_clause error like e.g.

```
exit with reason no function clause matching boss_record_lib:convert_value_to_type(<<"29.80">>, float) line 78
```

This approach at least seems to work, but if there are better ways of solving this, I won't object. ;-)
