### PR TITLE
Fix for saving new boss records with an uuid as id to pgsql

### DIFF
--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -192,8 +192,11 @@ id_value_to_string(Id) -> Id.
 
 maybe_populate_id_value(Record) ->
     case boss_sql_lib:keytype(Record) of 
-        uuid -> Record:set(id, uuid:to_string(uuid:uuid4()));
-        _ -> Record
+        uuid ->
+            Type = element(1, Record),
+            Record:set(id, lists:concat([Type, "-", uuid:to_string(uuid:uuid4())]));
+        _ ->
+            Record
 end.
 
 activate_record(Record, Metadata, Type) ->


### PR DESCRIPTION
The current state of the master branch results in the following error while trying to save a new boss record with an uuid as id to pgsql.

``` erlang
Saving Record id
...
** exception exit: {{undef,[{'39235764',module_info,[exports],[]},
                            {boss_record_lib,dummy_record,1,
                                             [{file,"src/boss_record_lib.erl"},{line,59}]},
                            {boss_record_lib,database_columns,1,
                                             [{file,"src/boss_record_lib.erl"},{line,77}]},
                            {boss_sql_lib,infer_type_from_id,1,
                                          [{file,"src/boss_sql_lib.erl"},{line,22}]},
                            {boss_db_adapter_pgsql,'-make_insert_attributes/2-fun-0-',4,
                                                   [{file,"src/db_adapters/boss_db_adapter_pgsql.erl"},
                                                    {line,274}]},
                            {lists,foldl,3,[{file,"lists.erl"},{line,1248}]},
                            {boss_db_adapter_pgsql,build_insert_query,1,
                                                   [{file,"src/db_adapters/boss_db_adapter_pgsql.erl"},
                                                    {line,243}]},
                            {boss_db_adapter_pgsql,save_record,2,
                                                   [{file,"src/db_adapters/boss_db_adapter_pgsql.erl"},
                                                    {line,119}]}]},
                    {gen_server,call,
                                [<0.100.0>,
                                 {save_record,{test,id,<<"foo">>,"bar"}},
                                 30000]}}
     in function  gen_server:call/3 (gen_server.erl, line 188)
     in call from boss_pool:call/3 (src/boss_pool.erl, line 12)
     in call from boss_db:save_record/1 (src/boss_db.erl, line 304)
```

The problem occurs at:

``` erlang
boss_sql_lib:infer_type_from_id/1
...
infer_type_from_id(Id) when is_list(Id) ->
    [Type, TableId] = re:split(Id, "-", [{return, list}, {parts, 2}]),
```

where re:split/2 tries to split the first token, which should be the model name, but instead is the first uuid digit group '39235764'. 
I'm not very familiar with boss_db but i think 07d039e should fix the error.
