### PR TITLE
Fixes for a proper usage of redis as a caching server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,29 @@ Usage
     ]
 
     CacheOptions = [
-        {adapter, memcached_bin}, % More in the future
-        {cache_servers, [{HostName::string(), Port::integer(), Weight::integer()}]}
+        {adapter, memcached_bin | redis | ets},
+        {cache_servers, MemcachedCacheServerOpts | RedisCacheServerOpts | EtsCacheServerOpts}
+    ]
+
+    MemcachedCacheServerOpts = [
+        { HostName::string() = "localhost"
+        , Port::integer()    = 11211
+        , Weight::integer()  = 1
+        }, ...
+    ]
+
+    RedisCacheServerOpts = [
+        {host,      HostName::string()   = "localhost"},
+        {port,      Port::integer()      = 6379},
+        {pass,      Password::string()   = undefined},
+        {db,        Db::integer()        = 0},
+        {reconnect, Reconnect::boolean() = true}
+    ]
+
+    EtsCacheServerOpts = [
+        {ets_maxsize,   MaxSize::integer() = 32 * 1024 * 1024},
+        {ets_threshold, Threshold::float() = 0.85},
+        {ets_weight,    Weight::integer()  = 30}
     ]
 
 Introduction

--- a/src/cache_adapters/boss_cache_adapter_redis.erl
+++ b/src/cache_adapters/boss_cache_adapter_redis.erl
@@ -6,24 +6,25 @@
 -export([get/3, set/5, delete/3]).
 
 start() ->
-    start([]).
+    ok.
 
-start(Options) ->
-    CacheServers = proplists:get_value(cache_servers, Options, []),
-    {ok, _Pid} = redo:start_link(undefined, CacheServers),
+start(_Options) ->
     ok.
 
 stop(Conn) ->
-    redo:shutdown(Conn). 
+    redo:shutdown(Conn).
 
-init(_Options) ->
-    {ok, undefined}.
+init(Options) ->
+    CacheServerOpts = proplists:get_value(cache_servers, Options, []),
+    redo:start_link(undefined, CacheServerOpts).
 
 terminate(_Conn) ->
     ok.
 
 get(Conn, Prefix, Key) ->
     case redo:cmd(Conn,["GET", term_to_key(Prefix, Key)]) of
+        undefined ->
+            undefined;
         Bin -> 
             binary_to_term(Bin)
     end.


### PR DESCRIPTION
Fixes for a proper usage of redis as a caching server and improvement of the README for clarification on how to configure the cache_servers option correct.
