### PR TITLE
Fix for ensuring that all parent directories exist while saving a compiled model

### DIFF
--- a/src/boss_compiler.erl
+++ b/src/boss_compiler.erl
@@ -67,6 +67,7 @@ compile(File, Options) ->
                         undefined -> ok;
                         OutDir ->
                             BeamFile = filename:join([OutDir, lists:concat([Module, ".beam"])]),
+                            filelib:ensure_dir(BeamFile),
                             file:write_file(BeamFile, Bin)
                     end,
                     {ok, Module};


### PR DESCRIPTION
The model compilation breaks in cases while the output directory (defaults to ebin) is not existing while trying to save them:

```
==> test_project (pre_compile)
unexpected error compiling src/model/test.erl
{'EXIT',{{badmatch,{error,enoent}},
         [{boss_compiler,compile,2,[{file,"src/boss_compiler.erl"},{line,66}]},
          {boss_db_rebar,compile_model,4,
                         [{file,"deps/boss_db/priv/rebar/boss_db_rebar.erl"},
                          {line,83}]},
          {rebar_base_compiler,compile,3,
                               [{file,"src/rebar_base_compiler.erl"},
                                {line,121}]},
          {rebar_base_compiler,compile_worker,3,
                               [{file,"src/rebar_base_compiler.erl"},
                                {line,194}]}]}}
ERROR: pre_compile failed while processing /private/tmp/test_project: rebar_abort
make: *** [compile-all] Error 1
```

This happens for example while cloning/creating a project.
