### PR TITLE
Fixed boss_db_rebar plugin to compile boss_db models before eunit

### DIFF
--- a/priv/rebar/boss_db_rebar.erl
+++ b/priv/rebar/boss_db_rebar.erl
@@ -37,31 +37,43 @@
 -module(boss_db_rebar).
 
 -export([pre_compile/2]).
+-export([pre_eunit/2]).
 
 %% @doc A pre-compile hook to compile boss_db models
-pre_compile(Config, _AppFile) ->
-    Opts = rebar_config:get(Config, boss_db_opts, []),
-    SourceDir = option(model_dir, Opts),
-    SourceExt = option(source_ext, Opts),
-    TargetDir = option(out_dir, Opts),
-    TargetExt = ".beam",
-    rebar_base_compiler:run(Config, [],
-        SourceDir,
-        SourceExt,
-        TargetDir,
-        TargetExt,
-        fun(S, T, _C) ->
-            compile_model(S, T, Opts, Config)
-        end,
-        [{check_last_mod, true},
-        {recursive, option(recursive, Opts)}]).
+pre_compile(RebarConf, _AppFile) ->
+    BossDbOpts = boss_db_opts(RebarConf),
+    pre_compile_helper(RebarConf, BossDbOpts, option(out_dir, BossDbOpts)).
+
+%% @doc A pre-eunit hook to compile boss_db models before eunit
+pre_eunit(RebarConf, _AppFile) ->
+    pre_compile_helper(RebarConf, boss_db_opts(RebarConf), ".eunit").
 
 %% --------------------------------------------------------------------
 %% Internal functions
 %% --------------------------------------------------------------------
 
-option(Opt, Opts) ->
-    proplists:get_value(Opt, Opts, option_default(Opt)).
+%% @doc Gets the boss_db options
+boss_db_opts(RebarConf) ->
+    rebar_config:get(RebarConf, boss_db_opts, []).
+
+%% @doc A pre-compile hook to compile boss_db models
+pre_compile_helper(RebarConf, BossDbOpts, TargetDir) ->
+    SourceDir = option(model_dir, BossDbOpts),
+    SourceExt = option(source_ext, BossDbOpts),
+    TargetExt = ".beam",
+    rebar_base_compiler:run(RebarConf, [],
+        SourceDir,
+        SourceExt,
+        TargetDir,
+        TargetExt,
+        fun(S, T, _C) ->
+            compile_model(S, T, BossDbOpts, RebarConf)
+        end,
+        [{check_last_mod, true},
+        {recursive, option(recursive, BossDbOpts)}]).
+
+option(Opt, BossDbOpts) ->
+    proplists:get_value(Opt, BossDbOpts, option_default(Opt)).
 
 option_default(model_dir) -> "src/model";
 option_default(out_dir)  -> "ebin";
@@ -69,16 +81,16 @@ option_default(source_ext) -> ".erl";
 option_default(recursive) -> false;
 option_default(compiler_options) -> [verbose, return_errors].
 
-compiler_options(ErlOpts, Opts) ->
-    set_debug_info_option(proplists:get_value(debug_info, ErlOpts), option(compiler_options, Opts)).
+compiler_options(ErlOpts, BossDbOpts) ->
+    set_debug_info_option(proplists:get_value(debug_info, ErlOpts), option(compiler_options, BossDbOpts)).
 
 set_debug_info_option(true, BossCompilerOptions) ->
     [debug_info | BossCompilerOptions];
 set_debug_info_option(undefined, BossCompilerOptions) ->
     BossCompilerOptions.
 
-compile_model(Source, _Target, Opts, RebarConfig) ->
+compile_model(Source, Target, BossDbOpts, RebarConfig) ->
     ErlOpts = rebar_config:get(RebarConfig, erl_opts, []),
-    RecordCompilerOpts = [{out_dir, option(out_dir, Opts)}, {compiler_options, compiler_options(ErlOpts, Opts)}],
+    RecordCompilerOpts = [{out_dir, filename:dirname(Target)}, {compiler_options, compiler_options(ErlOpts, BossDbOpts)}],
     boss_record_compiler:compile(Source, RecordCompilerOpts),
     ok.


### PR DESCRIPTION
I don't know if it's just an configuration problem from my side, but otherwise it seems that it's currently not possible to unit test OTP applications with eunit which depend on boss_db/models. `pre_compile/2` is only executed with `rebar compile` hence models doesn't get compiled with `rebar eunit`. With this fix I've implemented `pre_eunit/2` for the boss_db rebar plugin which compiles the models and save them to the `.eunit` folder instead of `ebin`.
