### PR TITLE
Accept ::uuid() data type.

### DIFF
--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -481,6 +481,8 @@ validate_record_types(Record) ->
                             true;
                         {Data, binary} when is_binary(Data) ->
                             true;
+                        {Data, uuid} when is_list(Data) ->
+                            true;
                         {{{D1, D2, D3}, {T1, T2, T3}}, datetime} when is_integer(D1), is_integer(D2), is_integer(D3),
                                                                       is_integer(T1), is_integer(T2), is_integer(T3) ->
                             true;


### PR DESCRIPTION
This is used in foreign keys, which should be able to declare that
they are ::uuid() rather than ::string() to match what is in the
database.
