### PR TITLE
Fix for ensuring that all parent directories exist while saving a compiled model

### DIFF
--- a/src/boss_compiler.erl
+++ b/src/boss_compiler.erl
@@ -86,6 +86,7 @@ write_beam(Options, Module, Bin) ->
         undefined -> ok;
         OutDir ->
             BeamFile = filename:join([OutDir, lists:concat([Module, ".beam"])]),
+            filelib:ensure_dir(BeamFile),
             file:write_file(BeamFile, Bin)
     end.
 


### PR DESCRIPTION
#151 / f03f5b49baf6585ac498a2120baeeddce8a6e927 got lost while refactoring the boss_compiler.
