### PR TITLE
test boss_cache_adapter_ets

### DIFF
--- a/src/boss_cache.erl
+++ b/src/boss_cache.erl
@@ -11,9 +11,15 @@ start() ->
 
 start(Options) ->
     AdapterName = proplists:get_value(adapter, Options, memcached_bin),
-    Adapter	= list_to_atom(lists:concat(["boss_cache_adapter_", AdapterName])),
-    Adapter:start(Options),
-    boss_cache_sup:start_link(Options).
+    case AdapterName of
+        ets ->
+	    {ok, CachePid} = boss_cache_adapter_ets:start(Options),
+	    boss_cache_sup:start_link([{ets_cachepid, CachePid} | Options]);
+	_ ->
+            Adapter = list_to_atom(lists:concat(["boss_cache_adapter_", AdapterName])),
+            Adapter:start(Options),
+	    boss_cache_sup:start_link(Options)
+    end.
 
 stop() ->
     ok.

--- a/src/cache_adapters/boss_cache_adapter_ets.erl
+++ b/src/cache_adapters/boss_cache_adapter_ets.erl
@@ -5,35 +5,40 @@
 -export([init/1, start/0, start/1, stop/1, terminate/1]).
 -export([get/3, set/5, delete/3]).
 
--spec start() -> 'ok'.
--spec start(_) -> 'ok'.
+-spec start() -> {'ok', pid()}.
+-spec start(_) -> {'ok', pid()}.
 -spec stop(_) -> 'ok'.
--spec init(_) -> {'ok','undefined'}.
--spec terminate(_) -> 'ok'.
--spec get(_,atom() | string() | number(),_) -> any().
--spec set(_,atom() | string() | number(),_,_,non_neg_integer()) -> 'ok'.
--spec delete(_,atom() | string() | number(),_) -> 'ok'.
+-spec init(_) -> {'ok',pid()} | {'error', string()}.
+-spec terminate(pid()) -> 'ok'.
+-spec get(pid(),atom() | string() | number(),_) -> 'undefined' | any().
+-spec set(pid(),atom() | string() | number(),_,_,non_neg_integer()) -> 'ok'.
+-spec delete(pid(),atom() | string() | number(),_) -> 'ok'.
 -spec term_to_key(atom() | string() | number(),_) -> string().
 
 start() ->
     {ok, CheckPid} = check_server:start_link(),
-    {ok, Conn} = cache_server:start_link([{checkpid, CheckPid}]),
-    Conn.
+    {ok, CachePid} = cache_server:start_link([{checkpid, CheckPid}]),
+    {ok, CachePid}.
 
 start(Options) ->
     {ok, CheckPid} = check_server:start_link(Options),
-    {ok, Conn} = cache_server:start_link([{checkpid, CheckPid}|Options]),
-    Conn.
+    {ok, CachePid} = cache_server:start_link([{checkpid, CheckPid} | Options]),
+    {ok, CachePid}.
 
 stop(Conn) ->
-    cache_server:stop(Conn).
+    cache_server:stop(Conn),
+    ok.
 
 init(Options) ->
-    Conn = start(Options),
-    {ok, Conn}.
+    case proplists:get_value(ets_cachepid, Options, error) of
+        error ->
+            {error, "boss_cache_adapter_ets hasn't started ets_cache"};
+	Conn ->
+            {ok, Conn}
+    end.
 
 terminate(Conn) ->
-    stop(Conn).
+    ok.
 
 get(Conn, Prefix, Key) ->
     Term2Key = term_to_key(Prefix, Key),
@@ -47,11 +52,13 @@ get(Conn, Prefix, Key) ->
 set(Conn, Prefix, Key, Val, TTL) ->
     Term2Key = term_to_key(Prefix, Key),
     ValBin = term_to_binary(Val),
-    cache_server:set(Conn, Term2Key, ValBin, TTL).
+    cache_server:set(Conn, Term2Key, ValBin, TTL),
+    ok.
 
 delete(Conn, Prefix, Key) ->
     Term2Key = term_to_key(Prefix, Key),
-    cache_server:delete(Conn, Term2Key).
+    cache_server:delete(Conn, Term2Key),
+    ok.
 
 % internal
 term_to_key(Prefix, Term) ->


### PR DESCRIPTION
In your CB app, you can enable ets cache to test now.

```
{cache_adapter, ets},
{ets_maxsize, 4194304}, %% 4*1024*1024
{ets_threshold, 0.85},
{ets_weight, 30}
{cache_enable, true},
%%    {cache_servers, [{"localhost", 11211, 1}]},
{cache_exp_time, 60},
```
