### PR TITLE
Do not react to normal exits

### DIFF
--- a/src/boss_db_controller.erl
+++ b/src/boss_db_controller.erl
@@ -251,6 +251,8 @@ code_change(_OldVsn, State, _Extra) ->
 handle_info(stop, State) ->
     {stop, shutdown, State};
 
+handle_info({'EXIT', _From, 'normal'}, State) ->
+    {noreply, State};
 handle_info({'EXIT', _From, _Reason}, State) when State#state.connection_state == connected ->
     {ok, Tref} = setup_reconnect(State),
     {noreply, State#state { connection_state = disconnected, connection_delay = State#state.connection_delay * 2,


### PR DESCRIPTION
Solves the problem with leaking connections for MongoDB (issue: #178). Do not know if this creates problems for other adapters though.
