### PR TITLE
allow custom type

### DIFF
--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -521,7 +521,7 @@ validate_record_types(Record) ->
                         {Data, atom} when is_atom(Data) ->
                             true;
                         {_Data, Type} ->
-                            false
+                            true
                     end,
                     if
                         GreatSuccess ->


### PR DESCRIPTION
use case:

``` erlang
-module(toto, [
               Id     ::pk(),
               Phone  ::phone(),
               Caviar ::string()
               Status ::picklist()
             ]).

```

would like to extend type, from the source code i see: 
  string, binary, uuid, date, datetime, integer, float, boolean, timestamp, atom

i guess this small change will not affect existing code, 
perhaps some test case.
