### PR TITLE
Avoid unneccessary call in get(Path)

### DIFF
--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -152,7 +152,11 @@ find(Key, Timeout) when is_list(Key), is_integer(Timeout) ->
     case db_call({find, IdToken}, Timeout) of
         undefined -> undefined;
         {error, Reason} -> {error, Reason};
-        BossRecord -> BossRecord:get(string:join(Rest, "."))
+        BossRecord ->
+            case Rest of
+                []   ->    BossRecord;
+                _    ->    BossRecord:get(string:join(Rest, "."))
+            end
     end;
 find(_, Timeout) when is_integer(Timeout) ->
     {error, invalid_id};


### PR DESCRIPTION
Avoid calling the module for processing dot-separated paths
if the path is not dot-separated.
