### PR TITLE
Add support for null values for type specified record parameters.

### DIFF
--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -495,38 +495,10 @@ validate_record_types(Record) ->
                 case Attr of
                   id -> Acc;
                   _  ->
-                    Data = Record:Attr(),
-                    GreatSuccess = case {Data, Type} of
-                        {undefined, _} ->
-                            true;
-                        {Data, string} when is_list(Data) ->
-                            true;
-                        {Data, binary} when is_binary(Data) ->
-                            true;
-                        {Data, uuid} when is_list(Data) ->
-                            true;
-                        {{{D1, D2, D3}, {T1, T2, T3}}, datetime} when is_integer(D1), is_integer(D2), is_integer(D3),
-                                                                      is_integer(T1), is_integer(T2), is_integer(T3) ->
-                            true;
-                        {{D1, D2, D3}, date} when is_integer(D1), is_integer(D2), is_integer(D3) ->
-                            true;
-                        {Data, integer} when is_integer(Data) ->
-                            true;
-                        {Data, float} when is_float(Data) ->
-                            true;
-                        {Data, boolean} when is_boolean(Data) ->
-                            true;
-                        {{N1, N2, N3}, timestamp} when is_integer(N1), is_integer(N2), is_integer(N3) ->
-                            true;
-                        {Data, atom} when is_atom(Data) ->
-                            true;
-                        {_Data, Type} ->
-                            false
-                    end,
-                    if
-                        GreatSuccess ->
-                            Acc;
+                    case validate_record_type({Record:Attr(), Type}) of
                         true ->
+                            Acc;
+                        false ->
                             [lists:concat(["Invalid data type for ", Attr])|Acc]
                     end
                   end
@@ -535,6 +507,36 @@ validate_record_types(Record) ->
         [] -> ok;
         _ -> {error, Errors}
     end.
+
+validate_record_type({undefined, _}) ->
+    true;
+validate_record_type({null, Types}) when is_list(Types) ->
+    lists:member(null, Types);
+validate_record_type({Data, Types}) when is_list(Types) ->
+    validate_record_type({Data, hd(lists:delete(null, Types))});
+validate_record_type({Data, string}) when is_list(Data) ->
+    true;
+validate_record_type({Data, binary}) when is_binary(Data) ->
+    true;
+validate_record_type({Data, uuid}) when is_list(Data) ->
+    true;
+validate_record_type({{{D1, D2, D3}, {T1, T2, T3}}, datetime}) when is_integer(D1), is_integer(D2), is_integer(D3),
+                                                                    is_integer(T1), is_integer(T2), is_integer(T3) ->
+    true;
+validate_record_type({{D1, D2, D3}, date}) when is_integer(D1), is_integer(D2), is_integer(D3) ->
+    true;
+validate_record_type({Data, integer}) when is_integer(Data) ->
+    true;
+validate_record_type({Data, float}) when is_float(Data) ->
+    true;
+validate_record_type({Data, boolean}) when is_boolean(Data) ->
+    true;
+validate_record_type({{N1, N2, N3}, timestamp}) when is_integer(N1), is_integer(N2), is_integer(N3) ->
+    true;
+validate_record_type({Data, atom}) when is_atom(Data) ->
+    true;
+validate_record_type({_Data, _Type}) ->
+    false.
 
 %% @spec type( Id::string() ) -> Type::atom()
 %% @doc Returns the type of the BossRecord with `Id', or `undefined' if the record does not exist.

--- a/src/boss_record_lib.erl
+++ b/src/boss_record_lib.erl
@@ -30,7 +30,7 @@
 -spec database_table(atom() | tuple()) -> any().
 -spec belongs_to_types(atom()) -> any().
 -spec ensure_loaded(atom()) -> boolean().
--type target_types() :: 'binary' | 'boolean' | 'date' | 'datetime' | 'float' | 'integer' | 'string' | 'timestamp' | 'undefined'.
+-type target_types() :: 'binary' | 'boolean' | 'date' | 'datetime' | 'float' | 'integer' | 'string' | 'timestamp' | 'undefined' | list().
 -spec convert_value_to_type(_,target_types()) -> any().
 
 run_before_hooks(Record, true) ->
@@ -116,6 +116,15 @@ ensure_loaded(Module) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 convert_value_to_type(Val, undefined) ->
     Val;
+convert_value_to_type(undefined, [H|_] = L) when is_atom(H) ->
+    case lists:member(null, L) of
+        true ->
+            null;
+        _ ->
+            throw({error, io_lib:format("Invalid attribute list ~p (attribute lists without null is not implemented)", [L])})
+    end;
+convert_value_to_type(Val, [H|_] = L) when is_atom(H) ->
+    convert_value_to_type(Val, hd(lists:delete(null, L)));
 convert_value_to_type(Val, integer) when is_integer(Val) ->
     Val;
 convert_value_to_type(Val, integer) when is_list(Val) ->

--- a/src/db_adapters/boss_db_adapter_mongodb.erl
+++ b/src/db_adapters/boss_db_adapter_mongodb.erl
@@ -549,7 +549,19 @@ unpack_value(_AttrName, [H|T], _ValueType) when is_integer(H) ->
     {integers, [H|T]};
 unpack_value(_AttrName, {_, _, _} = Value, datetime) ->
     calendar:now_to_datetime(Value);
+unpack_value(AttrName, undefined, ValueType) when is_list(ValueType) ->
+    convert_value_or_unpack_id(AttrName, undefined, ValueType);
+unpack_value(AttrName, Value, ValueType) when is_list(ValueType) ->
+    case lists:member(datetime, ValueType) of
+        true ->
+            calendar:now_to_datetime(Value);
+        false ->
+            convert_value_or_unpack_id(AttrName, Value, ValueType)
+    end;
 unpack_value(AttrName, Value, ValueType) ->
+    convert_value_or_unpack_id(AttrName, Value, ValueType).
+
+convert_value_or_unpack_id(AttrName, Value, ValueType) ->
     case is_id_attr(AttrName) and (Value =/= "") of 
         true -> 
             IdType = id_type_from_foreign_key(AttrName),


### PR DESCRIPTION
Currently only verified for mongodb.

Makes it possible to specify type, but allow null.

Syntax:

``` erlang
-module(my_module, [Id, Name::string() | null]).
```
