### PR TITLE
Support timestamps that the backend has already converted into 3-tuples.

### DIFF
--- a/src/boss_record_lib.erl
+++ b/src/boss_record_lib.erl
@@ -150,6 +150,8 @@ convert_value_to_type({{D1, D2, D3}, {T1, T2, T3}} = Val, timestamp) when is_int
                                                                           is_integer(T1), is_integer(T2), is_integer(T3) ->
     Secs = calendar:datetime_to_gregorian_seconds(Val) - calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}),
     {Secs rem ?MILLION, Secs div ?MILLION, 0};
+convert_value_to_type({N1, N2, N3} = Val, timestamp) when is_integer(N1), is_integer(N2), is_integer(N3) ->
+    Val;
 convert_value_to_type({{D1, D2, D3}, {T1, T2, T3}} = Val, datetime) when is_integer(D1), is_integer(D2), is_integer(D3), 
                                                                          is_integer(T1), is_integer(T2), is_integer(T3) ->
     Val;


### PR DESCRIPTION
The mongodb driver, at least, does this, so this adds support for timestamps in mongodb backends.
