### PR TITLE
Don't call convert_value_to_type for mongo timestamps, which are already...

### DIFF
--- a/src/db_adapters/boss_db_adapter_mongodb.erl
+++ b/src/db_adapters/boss_db_adapter_mongodb.erl
@@ -549,6 +549,8 @@ unpack_value(_AttrName, [H|T], _ValueType) when is_integer(H) ->
     {integers, [H|T]};
 unpack_value(_AttrName, {_, _, _} = Value, datetime) ->
     calendar:now_to_datetime(Value);
+unpack_value(_AttrName, {_, _, _} = Value, timestamp) ->
+    Value;
 unpack_value(AttrName, Value, ValueType) ->
     case is_id_attr(AttrName) and (Value =/= "") of 
         true -> 


### PR DESCRIPTION
... in the correct format.

Replaces #201, as this only affects the mongo adapter.
