### PR TITLE
Permit fetching undefined values also if the type is specified.

### DIFF
--- a/src/boss_record_lib.erl
+++ b/src/boss_record_lib.erl
@@ -116,6 +116,8 @@ ensure_loaded(Module) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 convert_value_to_type(Val, undefined) ->
     Val;
+convert_value_to_type(undefined, _) ->
+    undefined;
 convert_value_to_type(Val, integer) when is_integer(Val) ->
     Val;
 convert_value_to_type(Val, integer) when is_list(Val) ->


### PR DESCRIPTION
boss_db.erl permits `undefined` to be written to a database, no matter what type is specified (in `validate_record_types/1`), but in boss_record_lib.erl, in `convert_value_to_type/2`, it is not allowed if the type is specified. This means that `undefined` can be written to the database, but not fetched back, if the type is specified. This PR supersedes #200.
