### PR TITLE
Table_exists: expect table name, not model name

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -104,8 +104,8 @@ count(Pid, Type, Conditions) ->
 table_exists(Pid, TableName) when is_atom(TableName) ->
     Res = fetch(Pid, ["SELECT 1 FROM ", atom_to_list(TableName)," LIMIT 1"]),
     case Res of
-        {updated, _} ->
-            ok;
+        {data, _} ->
+            true;
         {error, MysqlRes} -> {error, mysql:get_result_reason(MysqlRes)}
     end.
 


### PR DESCRIPTION
1. Make API compatible with PostgreSQL adapter
2. Make it working when called with schema_migrations
3. It generally makes more sense to work with SQL table names,
   models can be renamed or deleted which would break old migrations.

This fixes #198.
