### PR TITLE
Separate delete from delete_counter

### DIFF
--- a/src/boss_cache_controller.erl
+++ b/src/boss_cache_controller.erl
@@ -31,7 +31,10 @@ handle_call({set, Prefix, Key, Value, TTL},
     {reply, Adapter:set(Conn, Prefix, Key, Value, TTL), State};
 handle_call({delete, Prefix, Key}, 
 	    _From, State = #state{adapter=Adapter, connection = Conn}) ->
-    {reply, Adapter:delete(Conn, Prefix, Key), State}.
+    {reply, Adapter:delete(Conn, Prefix, Key), State};
+handle_call({delete_counter, Prefix, Key},
+	    _From, State = #state{adapter=Adapter, connection = Conn}) ->
+    {reply, Adapter:delete_counter(Conn, Prefix, Key), State}.
 
 handle_cast(_Request, State) ->
     {noreply, State}.

--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -31,6 +31,8 @@
         incr/3, 
         delete/1, 
         delete/2, 
+        delete_counter/1,
+        delete_counter/2,
         push/0,
         push/1,
         pop/0,
@@ -263,8 +265,8 @@ count(Type, Conditions, Timeout) ->
 
 %% @spec counter( Id::string() ) -> integer()
 %% @doc Treat the record associated with `Id' as a counter and return its value.
-%% Returns 0 if the record does not exist, so to reset a counter just use
-%% "delete".
+%% Returns 0 if the record does not exist.
+
 counter(Key) ->
     counter(Key, ?DEFAULT_TIMEOUT).
 
@@ -309,6 +311,11 @@ delete(Key, Timeout) when is_integer(Timeout) ->
             end
     end.
 
+delete_counter(Key) ->
+    delete_counter(Key, ?DEFAULT_TIMEOUT).
+
+delete_counter(Key, Timeout) ->
+    db_call({delete_counter, Key}, Timeout).
 
 push() ->
     db_call(push).

--- a/src/boss_db_adapter.erl
+++ b/src/boss_db_adapter.erl
@@ -5,8 +5,8 @@
 behaviour_info(callbacks) ->
     [
         {start, 1}, {stop, 0}, {init, 1}, {terminate, 1},
-        {find, 2}, {find, 7}, {count, 3}, 
-        {delete, 2}, {counter, 2}, {incr, 3}, {save_record, 2}
+        {find, 2}, {find, 7}, {count, 3},
+        {delete, 2}, {delete_counter, 2}, {counter, 2}, {incr, 3}, {save_record, 2}
     ];
 behaviour_info(_Other) ->
     undefined.

--- a/src/boss_db_controller.erl
+++ b/src/boss_db_controller.erl
@@ -157,6 +157,10 @@ handle_call({delete, Id}, _From, State) ->
     {Adapter, _, Conn} = db_for_key(Id, State),
     {reply, Adapter:delete(Conn, Id), State};
 
+handle_call({delete_counter, Key}, _From, State) ->
+    {Adapter, _, Conn} = db_for_key(Key, State),
+    {reply, Adapter:delete_counter(Conn, Key), State};
+
 handle_call({save_record, Record}, _From, State) ->
     {Adapter, _, Conn} = db_for_record(Record, State),
     {reply, Adapter:save_record(Conn, Record), State};

--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -1,7 +1,7 @@
 -module(boss_db_adapter_pgsql).
 -behaviour(boss_db_adapter).
 -export([init/1, terminate/1, start/1, stop/0, find/2, find/7, find_by_sql/4]).
--export([count/3, counter/2, incr/3, delete/2, save_record/2]).
+-export([count/3, counter/2, incr/3, delete/2, delete_counter/2, save_record/2]).
 -export([push/2, pop/2, dump/1, execute/2, execute/3, transaction/2, create_table/3, table_exists/2]).
 -export([get_migrations_table/1, migration_done/3]).
 -compile(export_all).
@@ -118,13 +118,10 @@ incr(Conn, Id, Count) ->
 
 delete(Conn, Id) when is_list(Id) ->
     {_, TableName, IdColumn, TableId} = boss_sql_lib:infer_type_from_id(Id),
-    Res = pgsql:equery(Conn, ["DELETE FROM ", TableName, " WHERE ", IdColumn, " = $1"], [TableId]),
-    case Res of
-        {ok, _Count} -> 
-            pgsql:equery(Conn, "DELETE FROM counters WHERE name = $1", [Id]),
-            ok;
-        {error, Reason} -> {error, Reason}
-    end.
+    pgsql:equery(Conn, ["DELETE FROM ", TableName, " WHERE ", IdColumn, " = $1"], [TableId]).
+
+delete_counter(Conn, Key) ->
+    pgsql:equery(Conn, "DELETE FROM counters WHERE name = $1", [Key]).
 
 save_record(Conn, Record) when is_tuple(Record) ->
     RecordId = Record:id(),


### PR DESCRIPTION
Using delete for two different things - deleting records and deleting
keys from the counter table - was causing problems like:

https://github.com/ChicagoBoss/boss_db/issues/135

This commit introduces a delete_counter that only deletes keys from
the counter.  The delete function only deletes records.

Fixes #135 
