### PR TITLE
Point avtobiff/erlang-uuid library to the GitHub mirror

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
         {erlmc,         ".*",   {git, "git://github.com/bipthelin/erlmc.git",                   {tag, "3062f8deb7"}}},
         {mysql,         ".*",   {git, "git://github.com/dizzyd/erlang-mysql-driver.git",        {tag, "16cae84b5e"}}},
         {poolboy,       ".*",   {git, "git://github.com/devinus/poolboy.git",                   {tag, "64e1eaef0b"}}},
-        {uuid,          ".*",   {git, "git://gitorious.org/avtobiff/erlang-uuid.git",           {tag, "9cfe9666f1"}}},
+        {uuid,          ".*",   {git, "git://github.com/avtobiff/erlang-uuid.git",              {tag, "9cfe9666f1"}}},
         {redo,          ".*",   {git, "git://github.com/JacobVorreuter/redo.git",               {tag, "7c7eaef4cd"}}},
                                                                                                 % boss_branch for ets_cache
         {ets_cache,     ".*",   {git, "git://github.com/cuongth/ets_cache.git",                 {tag, "c7a17204cd"}}},


### PR DESCRIPTION
The dependency "git://gitorious.org/avtobiff/erlang-uuid.git" doesn't seem to work anymore. As of the fact that Gitorious was recently acquired by GitLab and gitorious.org will [shut down](https://about.gitlab.com/2015/03/03/gitlab-acquires-gitorious/) by end of May, I think it's unclear where @avtobiff will migrate the main developing repository to. So for now I would suggest to point to the GitHub mirror.