### PR TITLE
Fixed bug with ::now() and ::date() types for mock adapter

### DIFF
--- a/src/boss_db_mock_controller.erl
+++ b/src/boss_db_mock_controller.erl
@@ -70,7 +70,7 @@ handle_call({save_record, Record}, _From, [{Dict, IdCounter}|OldState]) ->
             ({Attr, {_, _, _} = Val} = Other) ->
                 AttributeTypes = Record:attribute_types(),
                 case proplists:get_value(Attr, AttributeTypes) of
-                    now ->
+                    timestamp ->
                         {Attr, calendar:now_to_datetime(Val)};
                     _ ->
                         Other

--- a/src/boss_db_mock_controller.erl
+++ b/src/boss_db_mock_controller.erl
@@ -67,8 +67,14 @@ handle_call({save_record, Record}, _From, [{Dict, IdCounter}|OldState]) ->
     NewAttributes = lists:map(fun
             ({id, _}) ->
                 {id, Id};
-            ({Attr, {_, _, _} = Val}) ->
-                {Attr, calendar:now_to_datetime(Val)};
+            ({Attr, {_, _, _} = Val} = Other) ->
+                AttributeTypes = Record:attribute_types(),
+                case proplists:get_value(Attr, AttributeTypes) of
+                    now ->
+                        {Attr, calendar:now_to_datetime(Val)};
+                    _ ->
+                        Other
+                end;
             (Other) ->
                 Other
         end, Record:attributes()),


### PR DESCRIPTION
How to reproduce:

-module(person_birthday, [Id, Day::date()]).
 
erlang> {person_birthday,id,{1984,18,2}}:save().
{ok,{person_birthday,"person_birthday-29", {{2032,9,28},{16,0,1}}}}