### PR TITLE
add space in boss_db_adapter_pgsql:option_to_sql to avoid SQL conjunction

### DIFF
--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -522,6 +522,6 @@ column_options_to_sql(Options) ->
 
 -spec(option_to_sql({not_null|primary_key, true}) -> string()).
 option_to_sql({not_null, true}) ->
-    "NOT NULL";
+    "NOT NULL ";
 option_to_sql({primary_key, true}) ->
-    "PRIMARY KEY".
+    "PRIMARY KEY ".


### PR DESCRIPTION
Avoid option string conjunction in generated SQL.
So error like this won't happen.

```erlang
boss_db:create_table(breeds, [{id, auto_increment, [{primary_key, true}, {not_null, true}]}, {name, string, [{not_null,true}]}  ]).
{error,{error,error,<<"42601">>,
              <<"syntax error at or near \"KEYNOT\"">>,
              [{position,<<"41">>}]}}
```