### PR TITLE
Introduce new before_update/1 and after_update/1 hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,16 @@ define one or more of these functions in your model file:
 
     before_create/0 -> ok | {ok, ModifiedRecord} | {error, Reason}
     before_update/0 -> ok | {ok, ModifiedRecord} | {error, Reason}
-    after_create/0 
+    before_update/1 -> ok | {ok, ModifiedRecord} | {error, Reason}
+    after_create/0
     after_update/0
+    after_update/1
     before_delete/0 -> ok | {error, Reason}
+
+The before_update/1 and after_update/1 hooks provide access to the old
+boss record as an additional parameter. If both hooks like before_update/0
+and before_update/1 exists in a boss model module, before_update/0 will
+be ignored. The same behaviour applies to after_update/1 and after_update/0.
 
 BossNews is more complicated but also more powerful. It is a notification
 system that executes asynchronously, so the code that calls "save" does

--- a/src/boss_db.erl
+++ b/src/boss_db.erl
@@ -411,7 +411,7 @@ save_record(Record, Timeout) ->
             % Action dependent valitation
             case validate_record(Record, IsNew) of
                 ok ->
-                    HookResult = case boss_record_lib:run_before_hooks(Record, IsNew) of
+                    HookResult = case boss_record_lib:run_before_hooks(OldRecord, Record, IsNew) of
                                      ok -> {ok, Record};
                                      {ok, Record1} -> {ok, Record1};
                                      {error, Reason} -> {error, Reason}


### PR DESCRIPTION
The new `before_update/1` and `after_update/1` hooks behave the same way as `before_update/0` and `after_update/0`. The difference is that they do provide access to the old boss record as an additional parameter.

This addition is fully backward compatible due to the fact that the `before_update/0` and `after_update/0` hooks act as fallbacks. For example, if both hooks like `before_update/0` and `before_update/1` exists in a boss model module, `before_update/0` will be ignored. The same behaviour applies to `after_update/0` and `after_update/1`.