### PR TITLE
Introduce a new option to enable SSL secured connections to a PostgreSQL server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Usage
         {db_username, UserName::string()},
         {db_password, Password::string()},
         {db_database, Database::string()},
+        {db_configure, DatabaseOptions::list()},
+        {db_ssl, UseSSL::boolean() | required}, % for now pgsql only
+
         {shards, [
             {db_shard_models, [ModelName::atom()]},
             {db_shard_id, ShardId::atom()},

--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -22,9 +22,17 @@ init(Options) ->
     DBUsername  = proplists:get_value(db_username, Options, "guest"),
     DBPassword  = proplists:get_value(db_password, Options, ""),
     DBDatabase  = proplists:get_value(db_database, Options, "test"),
+    DBSsl       = proplists:get_value(db_ssl, Options, false),
     DBConfigure = proplists:get_value(db_configure, Options, []),
-    pgsql:connect(DBHost, DBUsername, DBPassword, 
-        [{port, DBPort}, {database, DBDatabase} | DBConfigure]).
+
+    if
+        DBSsl == true orelse DBSsl == required ->
+            ssl:start();
+        true ->
+            ok
+    end,
+    pgsql:connect(DBHost, DBUsername, DBPassword,
+                  [{port, DBPort}, {database, DBDatabase}, {ssl, DBSsl} | DBConfigure]).
 
 terminate(Conn) ->
     pgsql:close(Conn).


### PR DESCRIPTION
This PR is based on #183. The missing default `if` clause is now included. In addition to `boolean()` as a data type for the `db_ssl` option, it's now possible to set `required` as an alternative, which corresponds to the underlying pgsql/epgsql library specification. The new option is now documented in the README and the missing `db_configure` option is also included.