### PR TITLE
Introduce EditorConfig file and add a contribution guideline for it

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[.travis.yml]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -293,3 +293,10 @@ are useful PKs when data are being aggregated from multiple sources.
 
 The default Id type ::serial() may be explicitly supplied.  Note that
 all Id types, valid or otherwise, pass type validation.
+
+Contribution Guidelines
+-----------------------
+
+Please ensure your pull request adheres to the following guidelines:
+
+* Please use [EditorConfig](http://editorconfig.org) to ensure consistent line-endings, tabs/spaces, etc. or make sure, that your editor does satisfy the coding styles defined within [.editorconfig](https://github.com/ErlyORM/boss_db/blob/master/.editorconfig).


### PR DESCRIPTION
While working on some tweaks and features for `boss_db` I've noticed that there are a lot of inconsistent whitespaces in the codebase. This whitespaces for example will be automatically converted by my IDE which in turn will mess up the actual changes. As many Editors/IDEs already support EditorConfig, I think this PR could be a start for a consistent codebase for future work.

I'll also create another PR with consistent whitespaces.