### PR TITLE
fixed redis cache adapter DEL command error.

### DIFF
--- a/src/cache_adapters/boss_cache_adapter_redis.erl
+++ b/src/cache_adapters/boss_cache_adapter_redis.erl
@@ -33,7 +33,7 @@ set(Conn, Prefix, Key, Val, TTL) ->
     redo:cmd(Conn,["SETEX",term_to_key(Prefix, Key), TTL, term_to_binary(Val)]).
 
 delete(Conn, Prefix, Key) ->
-    redo:cmd(Conn, ["DELETE", term_to_key(Prefix, Key)]).
+    redo:cmd(Conn, ["DEL", term_to_key(Prefix, Key)]).
 
 % internal
 term_to_key(Prefix, Term) ->


### PR DESCRIPTION
fix boss_cache_adapter_redis:delete() return ERR unknown command 'DELETE‘