### PR TITLE
Fix inflector pluralize irregulars

### DIFF
--- a/src/db_adapters/boss_db_adapter_mysql.erl
+++ b/src/db_adapters/boss_db_adapter_mysql.erl
@@ -211,7 +211,7 @@ do_transaction(Pid, TransactionFun) when is_function(TransactionFun) ->
     case do_begin(Pid, self()) of
         {error, _} = Err ->
             {aborted, Err};
-        {updated,{mysql_result,[],[],0,0,[]}} ->
+        {updated,{mysql_result,[],[],0,0,[],0,[]}} ->
             case catch TransactionFun() of
                 error = Err ->
                     do_rollback(Pid, self()),

--- a/src/inflector.erl
+++ b/src/inflector.erl
@@ -178,14 +178,14 @@ singulars() ->
       {"s$",                     ""      } ] ++ reversed_irregulars().
 
 irregulars() ->
-    [{"move",   "moves"   },
-     {"sex",    "sexes"   },
-     {"child",  "children"},
-     {"man",    "men"     },
-     {"person", "people"  }].
+    [{"move$",   "moves"   },
+     {"sex$",    "sexes"   },
+     {"child$",  "children"},
+     {"man$",    "men"     },
+     {"person$", "people"  }].
 
 reversed_irregulars() ->
-    F = fun ({A, B}) -> {B, A} end,
+    F = fun ({A, B}) -> {B ++ "$", re:replace(A, "\\$", "", [{return, list}])} end,
     lists:map(F, irregulars()).
 
 uncountables() ->
@@ -227,7 +227,8 @@ pluralize_test() ->
     "buses"			= pluralize("bus"),
     "sexes"			= pluralize("sex"),
     "sheep"			= pluralize("sheep"),
-    "children"			= pluralize("child").
+    "children"			= pluralize("child"),
+    "personal_websites" = pluralize("personal_website").
 
 camelize_test() ->
     "CamelCase"			= camelize("camel_case").


### PR DESCRIPTION
Fixed a bug in the pluralize module that occurs due to the incorrect regexp matching:
Old:
`inflector:pluralize("personal_website") -> "peopleal_website"`
New:
`inflector:pluralize("personal_website") -> "personal_websites"`
