### PR TITLE
fix: Cache invalidation on field update.

### DIFF
--- a/src/boss_db_cache.erl
+++ b/src/boss_db_cache.erl
@@ -16,11 +16,5 @@ handle_collection_news(updated, {_Record, Attr, _OldVal, _NewVal}, {Prefix, Key}
     boss_cache:delete(Prefix, Key),
     {ok, cancel_watch};
 handle_collection_news(updated, {_Record, Attr, _OldVal, _NewVal}, {Prefix, Key}) ->
-    Conditions = element(2, Key),
-    case proplists:lookup(Attr, Conditions) of
-        none ->
-            ok;
-        _ ->
-            boss_cache:delete(Prefix, Key),
-            {ok, cancel_watch}
-    end.
+    boss_cache:delete(Prefix, Key),
+    {ok, cancel_watch}.


### PR DESCRIPTION
This fixes a bug on boss_cache that doesn’t invalidate the cache when a field is updated.