### PR TITLE
fix dependence 'erlmc' in 'rebar.config' and 'rebar.config.script'

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 
         {ddb,           {git, "https://github.com/ErlyORM/ddb.git",                       {tag, "v0.1.7"}}},
         {epgsql,        {git, "https://github.com/epgsql/epgsql.git",                     {tag, "4.2.0"}}},
-        {erlmc,         {git, "https://github.com/layerhq/erlmc.git",                     {ref, "c5280da"}}},
+        {erlmc,         {git, "https://github.com/bipthelin/erlmc.git",                   {tag, "3062f8deb7ce0540dc85e5e791f146f0a8d7058d"}}},
         {mysql,         {git, "https://github.com/ErlyORM/erlang-mysql-driver.git",       {tag, "v0.0.4"}}},
         {poolboy,       {git, "https://github.com/devinus/poolboy.git",                   {tag, "1.5.2"}}},
         {uuid,          {git, "https://github.com/avtobiff/erlang-uuid.git",              {tag, "v0.5.2"}}},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -25,7 +25,7 @@ case erlang:function_exported(rebar3, main, 1) of
 
             {ddb,           ".*",   {git, "https://github.com/ErlyORM/ddb.git",                       {tag, "v0.1.7"}}},
             {epgsql,        ".*",   {git, "https://github.com/epgsql/epgsql.git",                     {tag, "4.2.0"}}},
-            {erlmc,         ".*",   {git, "https://github.com/layerhq/erlmc.git",                     {tag, "c5280da"}}},
+            {erlmc,         ".*",   {git, "https://github.com/bipthelin/erlmc.git",                   {tag, "3062f8deb7ce0540dc85e5e791f146f0a8d7058d"}}},
             {mysql,         ".*",   {git, "https://github.com/ErlyORM/erlang-mysql-driver.git",       {tag, "v0.0.4"}}},
             {poolboy,       ".*",   {git, "https://github.com/devinus/poolboy.git",                   {tag, "1.5.2"}}},
             {uuid,          ".*",   {git, "https://github.com/avtobiff/erlang-uuid.git",              {tag, "v0.5.2"}}},

--- a/src/cache_adapters/boss_cache_adapter_memcached_bin.erl
+++ b/src/cache_adapters/boss_cache_adapter_memcached_bin.erl
@@ -32,7 +32,7 @@ get(_Conn, Prefix, Key) ->
     end.
 
 set(_Conn, Prefix, Key, Val, TTL) ->
-    erlmc:set(term_to_key(Prefix, Key), term_to_binary(Val), TTL, 5000).
+    erlmc:set(term_to_key(Prefix, Key), term_to_binary(Val), TTL).
 
 delete(_Conn, Prefix, Key) ->
     erlmc:delete(term_to_key(Prefix, Key)).


### PR DESCRIPTION
Dependency was changed to actual:

> empty repository: `{erlmc,{git, "https://github.com/layerhq/erlmc.git",{ref, "c5280da"}}}`

> was changed to actual: `{erlmc, {git, "https://github.com/bipthelin/erlmc.git",{tag, "3062f8deb7ce0540dc85e5e791f146f0a8d7058d"}}}`